### PR TITLE
Basic Login settings

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+    <category label="Login">
+        <setting label="Email" type="text" id="email" default=""/>
+        <setting label="Password" type="text" id="password" default="" option="hidden"/>
+    </category>
+</settings>


### PR DESCRIPTION
Adds very basic Addon Settings including Email and Password. No validity check, no usage of the settings within other code parts, no localization (English only), but for the time being it should be enough to fulfill #2.