### PR TITLE
Add pylint and make code compliant

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,7 @@
+[BASIC]
+
+good-names=id
+
+[DESIGN]
+
+min-public-methods=1

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 Kodistubs = "*"
+pylint = "*"
 
 [packages]
 requests = "*"
@@ -12,3 +13,6 @@ beautifulsoup4 = "*"
 
 [requires]
 python_version = "2.7"
+
+[scripts]
+lint = "pylint main.py"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "65808ea9b7d946ef45345a4a5edd8ba15c021083f0051dc4d50d92a2d5710514"
+            "sha256": "536461a0872d69ee0e31c3e1cd0248f7f1feefb79d40811f9349bb5cf42ef20d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -80,6 +80,55 @@
         }
     },
     "develop": {
+        "astroid": {
+            "hashes": [
+                "sha256:87de48a92e29cedf7210ffa853d11441e7ad94cb47bacd91b023499b51cbc756",
+                "sha256:d25869fc7f44f1d9fb7d24fd7ea0639656f5355fc3089cd1f3d18c6ec6b124c7"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.6.6"
+        },
+        "backports.functools-lru-cache": {
+            "hashes": [
+                "sha256:0bada4c2f8a43d533e4ecb7a12214d9420e66eb206d54bf2d682581ca4b80848",
+                "sha256:8fde5f188da2d593bd5bc0be98d9abc46c95bb8a9dde93429570192ee6cc2d4a"
+            ],
+            "markers": "python_version < '3'",
+            "version": "==1.6.1"
+        },
+        "configparser": {
+            "hashes": [
+                "sha256:254c1d9c79f60c45dfde850850883d5aaa7f19a23f13561243a050d5a7c3fe4c",
+                "sha256:c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df"
+            ],
+            "markers": "python_version == '2.7'",
+            "version": "==4.0.2"
+        },
+        "enum34": {
+            "hashes": [
+                "sha256:a98a201d6de3f2ab3db284e70a33b0f896fbf35f8086594e8c9e74b909058d53",
+                "sha256:c3858660960c984d6ab0ebad691265180da2b43f07e061c0f8dca9ef3cffd328",
+                "sha256:cce6a7477ed816bd2542d03d53db9f0db935dd013b70f336a95c73979289f248"
+            ],
+            "markers": "python_version < '3.4'",
+            "version": "==1.1.10"
+        },
+        "futures": {
+            "hashes": [
+                "sha256:49b3f5b064b6e3afc3316421a3f25f66c137ae88f068abbf72830170033c5e16",
+                "sha256:7e033af76a5e35f58e56da7a91e687706faf4e7bdfb2cbc3f2cca6b9bcda9794"
+            ],
+            "markers": "python_version < '3.2'",
+            "version": "==3.3.0"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
+                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==4.3.21"
+        },
         "kodistubs": {
             "hashes": [
                 "sha256:a68ca61429d3d6925d108f1a0e7ec602096a3dbce5476e973ef8f81fc617ed96",
@@ -88,6 +137,65 @@
             "index": "pypi",
             "version": "==18.0.0"
         },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:00b78a97a79d0dfefa584d44dd1aba9668d3de7ec82335ba0ff51d53ef107143",
+                "sha256:042b54fd71c2092e6d10e5e66fa60f65c5954f8145e809f5d9f394c9b13d32ee",
+                "sha256:11f87dc06eb5f376cc6d5f0c19a1b4dca202035622777c4ce8e5b72c87b035d6",
+                "sha256:19ae6f6511a02008ef3554e158c41bb2a8e5c8455935b98d6da076d9f152fd7c",
+                "sha256:22c1935c6f8e3d6ea2e169eb03928adbdb8a2251d2890f8689368d65e70aa176",
+                "sha256:30ef2068f4f94660144515380ef04b93d15add2214eab8be4cd46ebc900d681c",
+                "sha256:33da47ba3a581860ddd3d38c950a5fe950ca389f7123edd0d6ab0bc473499fe7",
+                "sha256:3e8698dc384857413580012f4ca322d89e63ef20fc3d4635a5b606d6d4b61f6a",
+                "sha256:4fdd7113fc5143c72dacf415079eec42fcbe69cc9d3d291b4ca742e3a9455807",
+                "sha256:63b6d9a5077d54db271fcc6772440f7380ec3fa559d0e2497dbfae2f47c2c814",
+                "sha256:8133b63b05f12751cddd8e3e7f02ba39dc7cfa7d2ba99d80d7436f0ba26d6b75",
+                "sha256:89b8e5780e49753e2b4cd5aab45d3df092ddcbba3de2c4d4492a029588fe1758",
+                "sha256:8d82e27cbbea6edb8821751806f39f5dcfd7b46a5e23d27b98d6d8c8ec751df8",
+                "sha256:92cedd6e26712505adb1c17fab64651a498cc0102a80ba562ff4a2451088f57a",
+                "sha256:9723364577b79ad9958a68851fe2acb94da6fd25170c595516a8289e6a129043",
+                "sha256:c484020ad26973a14a7cb1e1d2e0bfe97cf6803273ae9bd154e0213cc74bad49",
+                "sha256:c697bd1b333b3e6abdff04ef9f5fb4b1936633d9cc4e28d90606705c9083254c",
+                "sha256:d0f7e14ff3424639d33e6bc449e77e4b345e52c21bbd6f6004a1d219196e2664",
+                "sha256:db2df3eff7ed3e6813638686f1bb5934d1a0662d9d3b4196b5164a86be3a1e8f",
+                "sha256:edbcb4c5efabd93ede05b272296a5a78a67e9b6e82ba7f51a07b8103db06ce01",
+                "sha256:ef355fb3802e0fc5a71dadb65a3c317bfc9bdf567d357f8e0b1900b432ffe486",
+                "sha256:fe2f61fed5817bf8db01d9a72309ed5990c478a077e9585b58740c26774bce39"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.5.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:367e3d49813d349a905390ac27989eff82ab84958731c5ef0bef867452cfdc42",
+                "sha256:97a42df23d436c70132971d1dcb9efad2fe5c0c6add55b90161e773caf729300"
+            ],
+            "index": "pypi",
+            "version": "==1.9.5"
+        },
+        "singledispatch": {
+            "hashes": [
+                "sha256:5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c",
+                "sha256:833b46966687b3de7f438c761ac475213e53b306740f1abfaa86e1d1aae56aa8"
+            ],
+            "markers": "python_version < '3.4'",
+            "version": "==3.4.0.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
+        },
         "typing": {
             "hashes": [
                 "sha256:1187fb9c82fd670d10aa07bbb6cfcfe4bdda42d6fab8d5134f04e8c4d0b71cc9",
@@ -95,6 +203,12 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.7.4.3"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
+            ],
+            "version": "==1.12.1"
         }
     }
 }

--- a/main.py
+++ b/main.py
@@ -1,3 +1,7 @@
+"""
+Kodi plugin to view means tv
+"""
+
 import re
 import sys
 from urlparse import parse_qsl
@@ -11,9 +15,9 @@ import xbmcaddon
 # Get the plugin url in plugin:// notation.
 from bs4 import BeautifulSoup
 
-_url = sys.argv[0]
+_URL = sys.argv[0]
 # Get the plugin handle as an integer number.
-_handle = int(sys.argv[1])
+_HANDLE = int(sys.argv[1])
 
 _STREAM_PROTOCOL = 'hls'
 _MEANS_TV_BASE_URL = 'https://means.tv/api'
@@ -27,18 +31,29 @@ else:
 
 
 class Category(object):
+    """
+    Main category from the start page
+    """
+
     def __init__(self, json):
         self.id = json['id']
         self.title = json['title']
 
     def to_directory_item(self):
+        """
+        :return: directory item tuple
+        """
         list_item = xbmcgui.ListItem(label=self.title)
         list_item.setInfo('video', {'title': self.title})
-        url = _url + '?show=category&id=' + str(self.id)
+        url = _URL + '?show=category&id=' + str(self.id)
         return url, list_item, True
 
 
 class Video(object):
+    """
+    A single video that is not part of any collection
+    """
+
     def __init__(self, json):
         self.id = json['permalink']
         self.title = json['title']
@@ -47,6 +62,9 @@ class Video(object):
         self.description = json['description']
 
     def to_directory_item(self):
+        """
+        :return: directory item tuple
+        """
         list_item = xbmcgui.ListItem(label=self.title)
         list_item.setInfo('video', {'title': self.title,
                                     'plot': self.clean_description(),
@@ -55,17 +73,27 @@ class Video(object):
                           'icon': self.thumb,
                           'fanart': self.thumb})
         list_item.setProperty('IsPlayable', 'true')
-        url = _url + '?show=video&id=' + str(self.id)
+        url = _URL + '?show=video&id=' + str(self.id)
         return url, list_item, False
 
     def duration_to_seconds(self):
+        """
+        :return: duration in seconds
+        """
         return duration_to_seconds(self.duration)
 
     def clean_description(self):
+        """
+        :return: description without html markup
+        """
         return strip_tags(self.description)
 
 
 class ChapterVideo(object):
+    """
+    The video chapter of a collection
+    """
+
     def __init__(self, json):
         self.id = json['id']
         self.position = json['position']
@@ -75,6 +103,9 @@ class ChapterVideo(object):
         self.description = json['description']
 
     def to_directory_item(self):
+        """
+        :return: directory item tuple
+        """
         title = str(self.position) + ". " + self.title
         list_item = xbmcgui.ListItem(label=title)
         list_item.setInfo('video', {'title': title,
@@ -84,17 +115,26 @@ class ChapterVideo(object):
                           'icon': self.thumb,
                           'fanart': self.thumb})
         list_item.setProperty('IsPlayable', 'true')
-        url = _url + '?show=chapter_video&id=' + str(self.id)
+        url = _URL + '?show=chapter_video&id=' + str(self.id)
         return url, list_item, False
 
     def duration_to_seconds(self):
+        """
+        :return: duration in seconds
+        """
         return duration_to_seconds(self.duration)
 
     def clean_description(self):
+        """
+        :return: description without html markup
+        """
         return strip_tags(self.description)
 
 
 class Collection(object):
+    """
+    The meta data of a collection
+    """
     def __init__(self, json):
         self.id = json['permalink']
         self.title = json['title']
@@ -102,91 +142,152 @@ class Collection(object):
         self.description = json['description']
 
     def to_directory_item(self):
+        """
+        :return: directory item tuple
+        """
         list_item = xbmcgui.ListItem(label=self.title)
         list_item.setInfo('video', {'title': self.title,
                                     'plot': self.clean_description()})
         list_item.setArt({'thumb': self.thumb,
                           'icon': self.thumb,
                           'fanart': self.thumb})
-        url = _url + '?show=collection&id=' + str(self.id)
+        url = _URL + '?show=collection&id=' + str(self.id)
         return url, list_item, True
 
     def clean_description(self):
+        """
+        :return: description without html markup
+        """
         return strip_tags(self.description)
 
 
 def duration_to_seconds(duration):
+    """
+    Convert duration string to seconds
+    :param duration: as string (either 00:00 or 00:00:00)
+    :return: duration in seconds :class:`int`
+    """
     array = duration.split(':')
     if len(array) == 2:
         return int(array[0]) * 60 + int(array[1])
-    else:
-        return int(array[0]) * 3600 + int(array[1]) * 60 + int(array[2])
+    return int(array[0]) * 3600 + int(array[1]) * 60 + int(array[2])
 
 
 def strip_tags(text):
+    """
+    Remove tags from text
+    :param text: string with html markup
+    :return: text without html markup
+    """
     if text:
         clean_text = BeautifulSoup(text, features='html.parser').get_text(separator=' ')
         return re.sub('\\s+', ' ', clean_text)
-    else:
-        return text
+    return text
 
 
 def to_category(json):
+    """
+    Convert category json to :class:`Category`
+    :param json: category as json
+    :return: :class:`Category`
+    """
     return Category(json)
 
 
 def to_directory_item(item):
+    """
+    Convert arbitrary item to a directory item tuple
+    :param item: object any class
+    :return: directory item tuple
+    """
     return item.to_directory_item()
 
 
 def load_categories():
+    """
+    Load categories from API
+    :return: list :class:`Category`
+    """
     url = _MEANS_TV_BASE_URL + '/categories'
-    r = requests.get(url)
-    json_list = r.json()
+    response = requests.get(url)
+    json_list = response.json()
     return map(to_category, json_list)
 
 
 def to_category_content(item):
+    """
+    Conver json list item from category content to video or collection
+    :param item: category content item (json)
+    :return: depending on content type :class:`Video` and :class:`Collection`
+    """
     content_type = item['content_type']
     if content_type == 'video':
         return Video(item)
-    else:
-        return Collection(item)
+    return Collection(item)
 
 
 def load_category_contents(category_id):
+    """
+    Load contents of a category
+    :param category_id: id of the category
+    :return: mixed list of :class:`Video` and :class:`Collection`
+    """
     url = _MEANS_TV_BASE_URL + '/contents?type=category_preview&category_id=' + str(category_id)
-    r = requests.get(url)
-    json_list = r.json()
+    response = requests.get(url)
+    json_list = response.json()
     return map(to_category_content, json_list)
 
 
 def load_collection(permalink):
+    """
+    Load collection from API
+    :param permalink: permalink id of collection
+    :return: json content of collection
+    """
     url = _MEANS_TV_BASE_URL + '/contents/' + permalink
-    r = requests.get(url)
-    return r.json()
+    response = requests.get(url)
+    return response.json()
 
 
 def to_chapter_video(json):
+    """
+    Convert json to :class:`ChapterVideo`
+    :param json: map of json content
+    :return: :class:`ChapterVideo`
+    """
     return ChapterVideo(json)
 
 
 def load_chapter_with_credentials(chapter_id):
+    """
+    Loading the content of a single chapter with logging in first to get stream URL
+    :param chapter_id: id of single chapter
+    :return: json content of chapter
+    """
     url = _MEANS_TV_BASE_URL + '/chapters/?ids[]=' + str(chapter_id)
     cookies = {'remember_user_token': get_token()}
-    r = requests.get(url, cookies=cookies)
-    return r.json()[0]
+    response = requests.get(url, cookies=cookies)
+    return response.json()[0]
 
 
 def load_chapters(chapters):
+    """
+    load the chapter details from the API without being logged in
+    :param chapters: list of chapter ids
+    :return: list of :class:`ChapterVideo`
+    """
     chapters_str = '&ids[]='.join(map(str, chapters))
     url = _MEANS_TV_BASE_URL + '/chapters/?ids[]=' + chapters_str
-    r = requests.get(url)
-    json_list = r.json()
+    response = requests.get(url)
+    json_list = response.json()
     return map(to_chapter_video, json_list)
 
 
 def show_chapter_video(chapter_id):
+    """
+    Show a video that is a chapter in the collection in kodi
+    :param chapter_id: id of the chapter in the collection
+    """
     chapter = load_chapter_with_credentials(chapter_id)
     url = chapter['subject']['versions']['hls']
     try:
@@ -194,15 +295,19 @@ def show_chapter_video(chapter_id):
         is_helper = inputstreamhelper.Helper('mpd', drm='widevine')
         if is_helper.check_inputstream():
             play_item = xbmcgui.ListItem(path=url)
-            play_item.setProperty('inputstreamaddon','inputstream.adaptive')
-            play_item.setProperty('inputstream.adaptive.manifest_type','hls')
+            play_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
+            play_item.setProperty('inputstream.adaptive.manifest_type', 'hls')
             play_item.setProperty(_INPUTSTREAM_PROPERTY, is_helper.inputstream_addon)
-            xbmcplugin.setResolvedUrl(_handle, True, play_item)
-    except Exception as e:
-        xbmc.log('Failed to load inputstream helper: ' + e.message)
+            xbmcplugin.setResolvedUrl(_HANDLE, True, play_item)
+    except ImportError as exception:
+        xbmc.log('Failed to load inputstream helper: ' + exception.message)
 
 
 def show_video(permalink):
+    """
+    Show a single video (without collection) in kodi
+    :param permalink: permalink id of the video
+    """
     collection = load_collection(permalink)
     show_chapter_video(collection['chapters'][0])
 
@@ -211,55 +316,63 @@ def list_collection(permalink):
     """
     List collection videos
     """
-    xbmcplugin.setPluginCategory(_handle, 'Category Contents')
-    xbmcplugin.setContent(_handle, 'videos')
+    xbmcplugin.setPluginCategory(_HANDLE, 'Category Contents')
+    xbmcplugin.setContent(_HANDLE, 'videos')
     collection = load_collection(permalink)
     videos = load_chapters(collection['chapters'])
     directory_items = map(to_directory_item, videos)
-    xbmcplugin.addDirectoryItems(_handle, directory_items, len(directory_items))
-    xbmcplugin.addSortMethod(_handle, xbmcplugin.SORT_METHOD_LABEL)
-    xbmcplugin.endOfDirectory(_handle)
+    xbmcplugin.addDirectoryItems(_HANDLE, directory_items, len(directory_items))
+    xbmcplugin.addSortMethod(_HANDLE, xbmcplugin.SORT_METHOD_LABEL)
+    xbmcplugin.endOfDirectory(_HANDLE)
 
 
 def list_category_contents(category_id):
     """
     List contents of a category
     """
-    xbmcplugin.setPluginCategory(_handle, 'Category Contents')
-    xbmcplugin.setContent(_handle, 'videos')
+    xbmcplugin.setPluginCategory(_HANDLE, 'Category Contents')
+    xbmcplugin.setContent(_HANDLE, 'videos')
     contents = load_category_contents(category_id)
     directory_items = map(to_directory_item, contents)
-    xbmcplugin.addDirectoryItems(_handle, directory_items, len(directory_items))
-    xbmcplugin.addSortMethod(_handle, xbmcplugin.SORT_METHOD_LABEL)
-    xbmcplugin.endOfDirectory(_handle)
+    xbmcplugin.addDirectoryItems(_HANDLE, directory_items, len(directory_items))
+    xbmcplugin.addSortMethod(_HANDLE, xbmcplugin.SORT_METHOD_LABEL)
+    xbmcplugin.endOfDirectory(_HANDLE)
 
 
 def list_categories():
     """
     List all categories
     """
-    xbmcplugin.setPluginCategory(_handle, 'Categories')
-    xbmcplugin.setContent(_handle, 'videos')
+    xbmcplugin.setPluginCategory(_HANDLE, 'Categories')
+    xbmcplugin.setContent(_HANDLE, 'videos')
     categories = load_categories()
     directory_items = map(to_directory_item, categories)
-    xbmcplugin.addDirectoryItems(_handle, directory_items, len(directory_items))
-    xbmcplugin.addSortMethod(_handle, xbmcplugin.SORT_METHOD_LABEL)
-    xbmcplugin.endOfDirectory(_handle)
+    xbmcplugin.addDirectoryItems(_HANDLE, directory_items, len(directory_items))
+    xbmcplugin.addSortMethod(_HANDLE, xbmcplugin.SORT_METHOD_LABEL)
+    xbmcplugin.endOfDirectory(_HANDLE)
 
 
 def get_credentials():
+    """
+    get credentials from addon settings
+    :return: username and password as tuple
+    """
     email = _ADDON.getSetting('email')
     password = _ADDON.getSetting('password')
     return email, password
 
 
 def get_token():
+    """
+    Retrieve user token from api through logging in
+    :return: token string
+    """
     (email, password) = get_credentials()
     url = _MEANS_TV_BASE_URL + '/sessions'
-    r = requests.post(url, json={'email': email, 'password': password})
-    if r.status_code >= 400:
-        raise ValueError('Unexpected status code {0}'.format(str(r.status_code)))
-    return r.cookies['remember_user_token']
+    response = requests.post(url, json={'email': email, 'password': password})
+    if response.status_code >= 400:
+        raise ValueError('Unexpected status code {0}'.format(str(response.status_code)))
+    return response.cookies['remember_user_token']
 
 
 def router(paramstring):


### PR DESCRIPTION
Ich habe [pylint](http://pylint.pycqa.org/en/latest/index.html) als linter hinzugefügt.

Damit der Code einigermaßen durch den Linter läuft, musste ich ihn ein bisschen ändern (hauptsächlich docstrings hinzufügen).

pylint kann man wie folgt laufen lassen:
```bash
pipenv run lint
```

Meine nächste Idee wäre es den Code als travis-ci build laufen zu lassen. Das ermöglicht es z.B. checks für PRs zu machen. D.h. der Linter läuft durch und [markiert den PR](https://blog.travis-ci.com/2018-05-07-announcing-support-for-github-checks-api-on-travis-ci-com) als konform oder nicht konform. Falls wir irgendwann mal Tests haben, könnten die ebenfalls so gestartet werden.

Das könnte, z.B. wenn andere Leute PRs machen, recht hilfreich sein, einen gewissen Standard im Code zu halten.

Kannst ja mal sagen, was du davon hältst.