### PR TITLE
Set collection description to videos with empty description

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -57,7 +57,7 @@ def load_chapters(chapters):
     url = _MEANS_TV_BASE_URL + '/chapters/?ids[]=' + chapters_str
     response = requests.get(url)
     json_list = response.json()
-    return map(to_chapter_video, json_list)
+    return [ChapterVideo(item) for item in json_list]
 
 
 def load_category_contents(category_id):
@@ -69,7 +69,7 @@ def load_category_contents(category_id):
     url = _MEANS_TV_BASE_URL + '/contents?type=category_preview&category_id=' + str(category_id)
     response = requests.get(url)
     json_list = response.json()
-    return map(to_category_content, json_list)
+    return [to_category_content(item) for item in json_list]
 
 
 def load_categories():
@@ -80,7 +80,7 @@ def load_categories():
     url = _MEANS_TV_BASE_URL + '/categories'
     response = requests.get(url)
     json_list = response.json()
-    return map(to_category, json_list)
+    return [Category(item) for item in json_list]
 
 
 def get_search_results(query):
@@ -96,7 +96,7 @@ def get_search_results(query):
         results.extend(results_for_page)
         page += 1
         results_for_page = _get_search_results_for_page(query, page)
-    return map(to_category_content, results)
+    return [to_category_content(item) for item in results]
 
 
 def _get_search_results_for_page(query, page):
@@ -137,31 +137,12 @@ def get_token(email, password):
     return response.cookies['remember_user_token']
 
 
-def to_category(json):
-    """
-    Convert category json to :class:`Category`
-    :param json: category as json
-    :return: :class:`Category`
-    """
-    return Category(json)
-
-
 def to_category_content(item):
     """
     Conver json list item from category content to video or collection
     :param item: category content item (json)
     :return: depending on content type :class:`Video` and :class:`Collection`
     """
-    content_type = item['content_type']
-    if content_type == 'video':
+    if item['content_type'] == 'video':
         return Video(item)
     return Collection(item)
-
-
-def to_chapter_video(json):
-    """
-    Convert json to :class:`ChapterVideo`
-    :param json: map of json content
-    :return: :class:`ChapterVideo`
-    """
-    return ChapterVideo(json)

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -21,16 +21,16 @@ class ApiError(Exception):
     pass
 
 
-def load_chapter_ids_of_collection(permalink):
+def load_collection(permalink):
     """
-    Loads chapter IDs of collection from API
+    Loads a single collection from API
     :param permalink: permalink id of collection
-    :return: list of int
+    :return: :class: `Collection`
     """
     url = _MEANS_TV_BASE_URL + '/contents/' + permalink
     response = requests.get(url)
     json = response.json()
-    return json['chapters']
+    return Collection(json)
 
 
 def load_stream_url_of_chapter(chapter_id, token):

--- a/resources/lib/handler.py
+++ b/resources/lib/handler.py
@@ -90,7 +90,7 @@ def list_collection(permalink):
     for video in videos:
         if not video.description:
             video.description = collection.description
-    directory_items = map(to_directory_item, videos)
+    directory_items = [v.to_directory_item() for v in videos]
     xbmcplugin.addDirectoryItems(_HANDLE, directory_items, len(directory_items))
     xbmcplugin.addSortMethod(_HANDLE, xbmcplugin.SORT_METHOD_LABEL)
     xbmcplugin.endOfDirectory(_HANDLE)
@@ -103,7 +103,7 @@ def list_category_contents(category_id):
     xbmcplugin.setPluginCategory(_HANDLE, 'Category Contents')
     xbmcplugin.setContent(_HANDLE, 'videos')
     contents = api.load_category_contents(category_id)
-    directory_items = map(to_directory_item, contents)
+    directory_items = [c.to_directory_item() for c in contents]
     xbmcplugin.addDirectoryItems(_HANDLE, directory_items, len(directory_items))
     xbmcplugin.addSortMethod(_HANDLE, xbmcplugin.SORT_METHOD_LABEL)
     xbmcplugin.endOfDirectory(_HANDLE)
@@ -130,7 +130,7 @@ def list_search_results(query):
     xbmcplugin.setPluginCategory(_HANDLE, 'Search results')
     xbmcplugin.setContent(_HANDLE, 'videos')
     contents = api.get_search_results(query)
-    directory_items = map(to_directory_item, contents)
+    directory_items = [c.to_directory_item() for c in contents]
     xbmcplugin.addDirectoryItems(_HANDLE, directory_items, len(directory_items))
     xbmcplugin.endOfDirectory(_HANDLE)
 
@@ -143,15 +143,6 @@ def list_categories():
     xbmcplugin.setContent(_HANDLE, 'videos')
     categories = api.load_categories()
     categories.insert(0, SearchItem())
-    directory_items = map(to_directory_item, categories)
+    directory_items = [c.to_directory_item() for c in categories]
     xbmcplugin.addDirectoryItems(_HANDLE, directory_items, len(directory_items))
     xbmcplugin.endOfDirectory(_HANDLE)
-
-
-def to_directory_item(item):
-    """
-    Convert arbitrary item to a directory item tuple
-    :param item: object any class
-    :return: directory item tuple
-    """
-    return item.to_directory_item()

--- a/resources/lib/handler.py
+++ b/resources/lib/handler.py
@@ -87,6 +87,9 @@ def list_collection(permalink):
     xbmcplugin.setContent(_HANDLE, 'videos')
     collection = api.load_collection(permalink)
     videos = api.load_chapters(collection.chapter_ids)
+    for video in videos:
+        if not video.description:
+            video.description = collection.description
     directory_items = map(to_directory_item, videos)
     xbmcplugin.addDirectoryItems(_HANDLE, directory_items, len(directory_items))
     xbmcplugin.addSortMethod(_HANDLE, xbmcplugin.SORT_METHOD_LABEL)

--- a/resources/lib/handler.py
+++ b/resources/lib/handler.py
@@ -85,8 +85,8 @@ def list_collection(permalink):
     """
     xbmcplugin.setPluginCategory(_HANDLE, 'Category Contents')
     xbmcplugin.setContent(_HANDLE, 'videos')
-    chapter_ids = api.load_chapter_ids_of_collection(permalink)
-    videos = api.load_chapters(chapter_ids)
+    collection = api.load_collection(permalink)
+    videos = api.load_chapters(collection.chapter_ids)
     directory_items = map(to_directory_item, videos)
     xbmcplugin.addDirectoryItems(_HANDLE, directory_items, len(directory_items))
     xbmcplugin.addSortMethod(_HANDLE, xbmcplugin.SORT_METHOD_LABEL)

--- a/resources/lib/handler.py
+++ b/resources/lib/handler.py
@@ -28,8 +28,8 @@ def show_video(permalink):
     Show a single video (without collection) in kodi
     :param permalink: permalink id of the video
     """
-    chapter_ids = api.load_chapter_ids_of_collection(permalink)
-    show_chapter_video(chapter_ids[0])
+    collection = api.load_collection(permalink)
+    show_chapter_video(collection.chapter_ids[0])
 
 
 def show_chapter_video(chapter_id):

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -19,7 +19,7 @@ class Collection(object):
         self.thumb = json['main_poster_featured']
         self.description = json['description']
         self.chapter_ids = json['chapters'] if 'chapters' in json else []
-        
+
     def to_directory_item(self):
         """
         :return: directory item tuple

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -18,7 +18,8 @@ class Collection(object):
         self.title = json['title']
         self.thumb = json['main_poster_featured']
         self.description = json['description']
-
+        self.chapter_ids = json['chapters'] if 'chapters' in json else []
+        
     def to_directory_item(self):
         """
         :return: directory item tuple

--- a/tests/resources/lib/it_api.py
+++ b/tests/resources/lib/it_api.py
@@ -1,7 +1,7 @@
 from __builtin__ import isinstance
 from unittest import TestCase
 
-from resources.lib.api import load_chapter_ids_of_collection, load_chapters, get_token, LoginError
+from resources.lib.api import load_collection, load_chapters, get_token, LoginError
 from resources.lib.model import ChapterVideo
 
 
@@ -9,9 +9,12 @@ class LoadChapterIdsForCollectionIntegrationTestCase(TestCase):
 
     def test_laughter_against_the_machine(self):
         # https://means.tv/programs/latm?categoryId=20473
-        expected = [1119397, 1119398, 1119399, 1119400, 1119401, 1119402, 1119404]
-        actual = load_chapter_ids_of_collection('latm')
-        self.assertEquals(actual, expected)
+        collection = load_collection('latm')
+        self.assertEquals(collection.id, 'latm')
+        self.assertEquals(collection.title, 'Laughter Against The Machine')
+        self.assertEquals(collection.thumb, 'https://dtsvkkjw40x57.cloudfront.net/images/programs/572687/horizontal/big_7507_2Fcatalog_image_2F572687_2FKCnCnqiQlimDLVneahyy_LATM_Thumbnails_3.png')
+        self.assertTrue(collection.clean_description().startswith('Laughter Against The Machine'))
+        self.assertEquals(collection.chapter_ids, [1119397, 1119398, 1119399, 1119400, 1119401, 1119402, 1119404])
 
 
 class LoadChapterDetailsIntegrationTestCase(TestCase):
@@ -20,7 +23,6 @@ class LoadChapterDetailsIntegrationTestCase(TestCase):
         # https://means.tv/programs/latm?categoryId=20473
         chapters = load_chapters([1119397, 1119398, 1119399, 1119400, 1119401, 1119402, 1119404])
         self.assertEquals(len(chapters), 7)
-        self.assertTrue(all([isinstance(c, ChapterVideo) for c in chapters]))
         self.assertEquals(chapters[0].title, 'Episode 1 - Arizona')
         self.assertEquals(chapters[0].position, 1)
         self.assertEquals(chapters[1].title, 'Episode 2 -  Chicago')

--- a/tests/resources/lib/test_api.py
+++ b/tests/resources/lib/test_api.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 import requests_mock
 
-from resources.lib.api import load_chapter_ids_of_collection, load_chapters, get_search_results
+from resources.lib.api import load_collection, load_chapters, get_search_results
 from resources.lib.model import ChapterVideo, Collection, Video
 
 _LATM_CONTENTS_JSON = os.path.join(os.path.dirname(__file__), 'latm_contents.json')
@@ -23,9 +23,13 @@ class LoadChapterIdsForCollectionTestCase(TestCase):
         with open(_LATM_CONTENTS_JSON, "r") as response_file:
             response_json = json.load(response_file)
             m.get('https://means.tv/api/contents/latm', json=response_json)
-        expected = [1119397, 1119398, 1119399, 1119400, 1119401, 1119402, 1119404]
-        actual = load_chapter_ids_of_collection('latm')
-        self.assertEquals(actual, expected)
+        collection = load_collection('latm')
+        self.assertTrue(isinstance(collection, Collection))
+        self.assertEquals(collection.id, 'latm')
+        self.assertEquals(collection.title, 'Laughter Against The Machine')
+        self.assertEquals(collection.thumb, 'https://dtsvkkjw40x57.cloudfront.net/images/programs/572687/horizontal/big_7507_2Fcatalog_image_2F572687_2FKCnCnqiQlimDLVneahyy_LATM_Thumbnails_3.png')
+        self.assertTrue(collection.clean_description().startswith('Laughter Against The Machine'))
+        self.assertEquals(collection.chapter_ids, [1119397, 1119398, 1119399, 1119400, 1119401, 1119402, 1119404])
 
 
 class LoadChapterDetailsTestCase(TestCase):


### PR DESCRIPTION
- Replaced `load_chapter_ids_of_collection(permalink)` by `load_collection(permalink)`now returning the whole collection details and not only the chapter ids.
- Collection details are used in `list_collection(permalink)` to replace empty video descriptions by the collection description.
- Refactoring: Replaced all `map(to_directory_item, ...)` in handler.py by list comprehension, for example: `[c.to_directory_item() for c in contents]`; deleted `to_directory_item(item)` in handler.py.
- Refactoring: Replaced all `map(...)` in api.py by list comprehension

Fixes #26 