### PR TITLE
Convert some HTML symbols in strip_tags(text)

### DIFF
--- a/resources/lib/formatting.py
+++ b/resources/lib/formatting.py
@@ -20,7 +20,7 @@ def duration_to_seconds(duration):
 
 def strip_tags(text):
     """
-    Remove tags from text
+    Remove html tags from text and convert a small set of html-encoded symbols
     :param text: string with html markup
     :return: text without html markup
     """
@@ -28,5 +28,7 @@ def strip_tags(text):
         clean_text = re.sub('<[^<]+?>', ' ', text)
         clean_text = clean_text.strip()
         clean_text = re.sub('\\s+', ' ', clean_text.strip())
+        clean_text = clean_text.replace('&amp;', '&')
+        clean_text = clean_text.replace('&nbsp;', ' ')
         return clean_text
     return text

--- a/resources/lib/formatting.py
+++ b/resources/lib/formatting.py
@@ -18,7 +18,7 @@ def duration_to_seconds(duration):
     return int(array[0]) * 3600 + int(array[1]) * 60 + int(array[2])
 
 
-def strip_tags(text):
+def clean_html(text):
     """
     Remove html tags from text and convert a small set of html-encoded symbols
     :param text: string with html markup

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -36,7 +36,7 @@ class Collection(object):
         """
         :return: description without html markup
         """
-        return formatting.strip_tags(self.description)
+        return formatting.clean_html(self.description)
 
 
 class ChapterVideo(object):
@@ -78,7 +78,7 @@ class ChapterVideo(object):
         """
         :return: description without html markup
         """
-        return formatting.strip_tags(self.description)
+        return formatting.clean_html(self.description)
 
 
 class Video(object):
@@ -118,7 +118,7 @@ class Video(object):
         """
         :return: description without html markup
         """
-        return formatting.strip_tags(self.description)
+        return formatting.clean_html(self.description)
 
 
 class Category(object):

--- a/tests/resources/lib/test_formatting.py
+++ b/tests/resources/lib/test_formatting.py
@@ -1,28 +1,28 @@
 from unittest import TestCase
 
-from resources.lib.formatting import strip_tags, duration_to_seconds
+from resources.lib.formatting import clean_html, duration_to_seconds
 
 
 class StripTagsTestCase(TestCase):
 
     def test_for_none_returns_none(self):
-        self.assertEquals(strip_tags(None), None)
+        self.assertEquals(clean_html(None), None)
 
     def test_for_empty_string_returns_empty_string(self):
-        self.assertEquals(strip_tags(""), "")
+        self.assertEquals(clean_html(""), "")
 
     def test_without_tags_returns_same_string(self):
-        self.assertEquals(strip_tags("No tags at all"), "No tags at all")
+        self.assertEquals(clean_html("No tags at all"), "No tags at all")
 
     def test_with_tags_returns_string_without_tags(self):
-        self.assertEquals(strip_tags("<p>something</p>"), "something")
+        self.assertEquals(clean_html("<p>something</p>"), "something")
 
     def test_with_tags_returns_string_without_tags_separates_by_single_space(self):
-        self.assertEquals(strip_tags("<h1>headline</h1><p>something <b>with</b> <i>tags</i></p>"),
+        self.assertEquals(clean_html("<h1>headline</h1><p>something <b>with</b> <i>tags</i></p>"),
                           "headline something with tags")
 
     def test_longer_real_world_text(self):
-        self.assertEquals(strip_tags("<p><strong><em>Laughter Against The Machine</em></strong> is a seven part documentary series following comedians W. Kamau Bell, Nato Green, and Janine Brito as they journey across the U.S. in 2011 before and after Occupy protests rock the nation.</p><p>The trio visits some of the least funny places in the world, like the militarized US/Mexico border, the 9th Ward in New Orleans that was devastated by Hurricane Katrina, or Oakland under martial law during Occupy. Amidst this grim political backdrop, the comics try and help their audiences unwind between being teargassed by cops or arrested for blocking ICE deportations.</p><p><br></p><p>Released in 2020</p>"),
+        self.assertEquals(clean_html("<p><strong><em>Laughter Against The Machine</em></strong> is a seven part documentary series following comedians W. Kamau Bell, Nato Green, and Janine Brito as they journey across the U.S. in 2011 before and after Occupy protests rock the nation.</p><p>The trio visits some of the least funny places in the world, like the militarized US/Mexico border, the 9th Ward in New Orleans that was devastated by Hurricane Katrina, or Oakland under martial law during Occupy. Amidst this grim political backdrop, the comics try and help their audiences unwind between being teargassed by cops or arrested for blocking ICE deportations.</p><p><br></p><p>Released in 2020</p>"),
                           "Laughter Against The Machine is a seven part documentary series following comedians W. Kamau Bell, Nato Green, and Janine Brito as they journey across the U.S. in 2011 before and after Occupy protests rock the nation. The trio visits some of the least funny places in the world, like the militarized US/Mexico border, the 9th Ward in New Orleans that was devastated by Hurricane Katrina, or Oakland under martial law during Occupy. Amidst this grim political backdrop, the comics try and help their audiences unwind between being teargassed by cops or arrested for blocking ICE deportations. Released in 2020")
 
 


### PR DESCRIPTION
I've grabbed [all current descriptions](https://github.com/xabgesagtx/meanstv-research/blob/master/meanstvdesc_20200922.txt) from Means.TV and found out that only the HTML symbols `&amp;` and `&nbsp;` appear. So, I added the conversion for these symbols to `strip_tags(text)` in formatting.py.

Shall we now rename this function since it's not only stripping tags anymore?