### PR TITLE
Changes for python 3 compatibility plus pylint compatibility check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,11 @@ jobs:
       with:
         python-version: '2.7'
     - uses: dschep/install-pipenv-action@v1
-    - run: pipenv install -d
-    - run: pipenv run lint
-    - run: pipenv run test
+    - name: install dependencies
+      run: pipenv install -d
+    - name: run python2 lint
+      run: pipenv run lint
+    - name: run python3 compatibility lint
+      run: pipenv run lint3
+    - name: run tests
+      run: pipenv run test

--- a/Pipfile
+++ b/Pipfile
@@ -16,5 +16,6 @@ python_version = "2.7"
 
 [scripts]
 lint = "pylint main.py resources"
+lint3 = "pylint --py3k main.py resources"
 test = "python -m unittest discover"
 it = "python -m unittest discover -p 'it_*.py'"

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 """
 Kodi plugin to view means tv
 """
+from __future__ import absolute_import
 import sys
 
 from resources.lib import router

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -1,6 +1,7 @@
 """
 Module for all means TV api access
 """
+from __future__ import absolute_import
 import requests
 
 from resources.lib.model import Video, Collection, ChapterVideo, Category

--- a/resources/lib/formatting.py
+++ b/resources/lib/formatting.py
@@ -1,6 +1,7 @@
 """
 Helper module for formatting input from means TV
 """
+from __future__ import absolute_import
 import re
 
 def duration_to_seconds(duration):

--- a/resources/lib/handler.py
+++ b/resources/lib/handler.py
@@ -1,6 +1,7 @@
 """
 Module to handle UI requests
 """
+from __future__ import absolute_import
 import sys
 
 import xbmc
@@ -75,8 +76,8 @@ def play(url):
             play_item.setProperty('inputstream.adaptive.manifest_type', 'hls')
             play_item.setProperty(_INPUTSTREAM_PROPERTY, is_helper.inputstream_addon)
             xbmcplugin.setResolvedUrl(_HANDLE, True, play_item)
-    except ImportError as err:
-        xbmc.log('Failed to load inputstream helper: ' + err.message)
+    except ImportError:
+        xbmc.log('Failed to load inputstream helper')
 
 
 def list_collection(permalink):

--- a/resources/lib/helper.py
+++ b/resources/lib/helper.py
@@ -1,7 +1,7 @@
 """
 Module with UI helpers
 """
-
+from __future__ import absolute_import
 import xbmc
 import xbmcgui
 

--- a/resources/lib/login.py
+++ b/resources/lib/login.py
@@ -1,6 +1,7 @@
 """
 Module to handle UI requests
 """
+from __future__ import absolute_import
 from datetime import datetime
 
 import xbmc

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -1,6 +1,7 @@
 """
 Model classes
 """
+from __future__ import absolute_import
 import sys
 
 import xbmcgui

--- a/resources/lib/router.py
+++ b/resources/lib/router.py
@@ -1,7 +1,11 @@
 """
 Route requests to plugin functionality
 """
-from urlparse import parse_qsl
+from __future__ import absolute_import
+try:
+    from urllib.parse import parse_qsl
+except ImportError:
+    from urlparse import parse_qsl
 
 from resources.lib import handler
 

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -1,6 +1,7 @@
 """
 Addon settings module
 """
+from __future__ import absolute_import
 import xbmcaddon
 
 _ADDON = xbmcaddon.Addon()


### PR DESCRIPTION
Kodi 19 uses python 3 but the plugin should still run in kodi 18 (python 2)
* enabled a python 3 compatibility check using pylint.
* check runs as part of the integration workflow additional to the python 2 lint
* I changed code as suggested by pylint

Note: This is not considering any potential changes in the kodi 19 api

 
Closes #32 