### PR TITLE
Change plugin name and description

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.meanstv"
 version="0.1.0"
-name="Means TV Kodi Plugin"
-provider-name="some_developers">
+name="Means TV"
+provider-name="surplustv">
 <requires>
   <import addon="xbmc.python" version="2.26.0"/>
   <import addon="script.module.requests" version="2.4.3"/>
@@ -12,9 +12,9 @@ provider-name="some_developers">
   <provides>video</provides>
 </extension>
 <extension point="xbmc.addon.metadata">
-  <summary lang="en">Means TV Kodi Video Plugin</summary>
-  <description lang="en_GB">Plugin to watch Means TV videos with Kodi</description>
-  <disclaimer lang="en_GB">Unofficial plugin. All videos are owned by means.tv</disclaimer>
+  <summary lang="en">Means TV</summary>
+  <description lang="en_GB">Means TV is the world’s first worker-owned, post-capitalist streaming service.</description>
+  <disclaimer lang="en_GB">Unofficial plugin. All videos are owned by Means TV</disclaimer>
   <assets>
     <icon>icon.png</icon>
   </assets>

--- a/addon.xml
+++ b/addon.xml
@@ -18,6 +18,9 @@ provider-name="surplustv">
   <assets>
     <icon>icon.png</icon>
   </assets>
+  <platform>all</platform>
+  <website>https://means.tv</website>
+  <source>https://github.com/surplustv/plugin.video.meanstv</source>
   <news>First implementation</news>
 </extension>
 </addon>


### PR DESCRIPTION
* changed all wording to "Means TV" (this seems to be the official wording on their website)
* took single sentence self description from https://means.tv/pages/about
* no mentioning that this is a plugin/addon anymore
* added website link, source URL and platform specification

Just to make it somewhat ready for publishing. Metada could maybe be more... Feel free to add or amend.

Closes #30 