### PR TITLE
Adapt to api changes

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -6,7 +6,10 @@ import requests
 
 from resources.lib.model import Video, Collection, ChapterVideo, Category
 
+_FASTLY_ORIGIN_HEADER = 'X-Fastly-Origin'
+_FASTLY_ORIGIN_HEADER_VALUE = 'meansmediatv'
 _MEANS_TV_BASE_URL = 'https://means.tv/api'
+
 
 class LoginError(Exception):
     """
@@ -64,7 +67,7 @@ def load_chapters(chapters):
     url = _MEANS_TV_BASE_URL + '/chapters/?ids[]=' + chapters_str
     response = requests.get(url)
     json_list = response.json()
-    return [ChapterVideo(item) for item in json_list]
+    return [ChapterVideo(item) for item in json_list if item['chapter_type'] == 'video']
 
 
 def load_category_contents(category_id):
@@ -85,7 +88,7 @@ def load_categories():
     :return: list of :class:`Category`
     """
     url = _MEANS_TV_BASE_URL + '/categories'
-    response = requests.get(url)
+    response = requests.get(url, headers={_FASTLY_ORIGIN_HEADER: _FASTLY_ORIGIN_HEADER_VALUE})
     json_list = response.json()
     return [Category(item) for item in json_list]
 

--- a/tests/resources/lib/it_api.py
+++ b/tests/resources/lib/it_api.py
@@ -1,8 +1,7 @@
-from __builtin__ import isinstance
 from unittest import TestCase
 
-from resources.lib.api import load_collection, load_chapters, get_token, load_stream_url_of_chapter, LoginError
-from resources.lib.model import ChapterVideo
+from resources.lib.api import load_collection, load_chapters, get_token, load_stream_url_of_chapter, LoginError, \
+    load_categories
 
 
 class LoadChapterIdsForCollectionIntegrationTestCase(TestCase):
@@ -65,3 +64,12 @@ class LoadStreamUrlOfChapter(TestCase):
         chapter = 1206515
         old_token = 'W1szODU1NTI0XSwiJDJhJDEwJEN6VWtDSFFneWRJSzhHZUx6ak0vVWUiLCIxNTk5NDExMTI1LjE4ODkxOTUiXQ%3D%3D--bd84f8019a8dff072dc6a71a52cba035483d6331'
         self.assertRaises(LoginError, lambda: load_stream_url_of_chapter(chapter, old_token))
+
+
+class LoadCategories(TestCase):
+
+    def test_load_categories(self):
+        categories = load_categories()
+        self.assertGreater(len(categories), 0)
+        self.assertTrue(all(category for category in categories if category.title), "All categories should have a title")
+        self.assertTrue(all(category for category in categories if category.id), "All categories should have an id")

--- a/tests/resources/lib/latm_chapters.json
+++ b/tests/resources/lib/latm_chapters.json
@@ -1,1 +1,197 @@
-[{"id":1119397,"title":"Episode 1 - Arizona","created_at":"2020-08-01T02:41:22.642-04:00","content_id":572687,"subject":{"duration":"11:49","preview_image_url":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640481/7507_2Fplayer_image_2F640481_2FrGLWEiLAQ8288L28tIXj_1_20-_20ARIZONA.jpg","versions":{"hls":""},"subtitles":[{"id":19274,"language":"en","vtt_file":{"url":"https://dtsvkkjw40x57.cloudfront.net/sub/19274/7507_2Fsubtitles_2F5agErxdtQWuQym8IaeIG_Episode_201_20_Final_3_.vtt"},"label":"English CC"}]},"position":1,"preview_image":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640481/7507_2Fplayer_image_2F640481_2FrGLWEiLAQ8288L28tIXj_1_20-_20ARIZONA.jpg","description":null,"downloadable":false,"chapter_type":"video","wait_for_drip":null,"drip_in":0,"has_access":true,"download_url":"","subject_id":640481},{"id":1119398,"title":"Episode 2 -  Chicago","created_at":"2020-08-01T02:41:22.692-04:00","content_id":572687,"subject":{"duration":"10:51","preview_image_url":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640480/7507_2Fplayer_image_2F640480_2FLvVqJ0leR46xl8fpMajp_2_20-_20CHICAGO.jpg","versions":{"hls":""},"subtitles":[]},"position":2,"preview_image":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640480/7507_2Fplayer_image_2F640480_2FLvVqJ0leR46xl8fpMajp_2_20-_20CHICAGO.jpg","description":null,"downloadable":false,"chapter_type":"video","wait_for_drip":null,"drip_in":0,"has_access":false,"download_url":"","subject_id":640480},{"id":1119399,"title":"Episode 3 - Dearborn","created_at":"2020-08-01T02:41:22.767-04:00","content_id":572687,"subject":{"duration":"10:46","preview_image_url":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640479/7507_2Fplayer_image_2F640479_2Ftyj7pwjDTaSZTibQBNri_3_20-_20_20DEARBORN.jpg","versions":{"hls":""},"subtitles":[]},"position":3,"preview_image":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640479/7507_2Fplayer_image_2F640479_2Ftyj7pwjDTaSZTibQBNri_3_20-_20_20DEARBORN.jpg","description":null,"downloadable":false,"chapter_type":"video","wait_for_drip":null,"drip_in":0,"has_access":false,"download_url":"","subject_id":640479},{"id":1119400,"title":"Episode 4 - Wisconsin","created_at":"2020-08-01T02:41:22.835-04:00","content_id":572687,"subject":{"duration":"10:08","preview_image_url":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640476/7507_2Fplayer_image_2F640476_2FvovGCeehTaSZPI2dysx6_WISCONSIN_20THUMB_203.jpg","versions":{"hls":""},"subtitles":[]},"position":4,"preview_image":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640476/7507_2Fplayer_image_2F640476_2FvovGCeehTaSZPI2dysx6_WISCONSIN_20THUMB_203.jpg","description":null,"downloadable":false,"chapter_type":"video","wait_for_drip":null,"drip_in":0,"has_access":false,"download_url":"","subject_id":640476},{"id":1119401,"title":"Episode 5 - NYC & DC","created_at":"2020-08-01T02:41:22.900-04:00","content_id":572687,"subject":{"duration":"12:13","preview_image_url":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640482/7507_2Fplayer_image_2F640482_2FxchqiVZoQECBMMubW0b7_5_20-_20Nyc_20DC.jpg","versions":{"hls":""},"subtitles":[]},"position":5,"preview_image":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640482/7507_2Fplayer_image_2F640482_2FxchqiVZoQECBMMubW0b7_5_20-_20Nyc_20DC.jpg","description":null,"downloadable":false,"chapter_type":"video","wait_for_drip":null,"drip_in":0,"has_access":false,"download_url":"","subject_id":640482},{"id":1119402,"title":"Episode 6 - New Orleans","created_at":"2020-08-01T02:41:22.976-04:00","content_id":572687,"subject":{"duration":"10:22","preview_image_url":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640477/7507_2Fplayer_image_2F640477_2F0vKymLVXR3yi9Uu8arb8_6_20-_20NEW_20ORLEANS.jpg","versions":{"hls":""},"subtitles":[]},"position":6,"preview_image":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640477/7507_2Fplayer_image_2F640477_2F0vKymLVXR3yi9Uu8arb8_6_20-_20NEW_20ORLEANS.jpg","description":null,"downloadable":false,"chapter_type":"video","wait_for_drip":null,"drip_in":0,"has_access":false,"download_url":"","subject_id":640477},{"id":1119404,"title":"Episode 7 - Oakland","created_at":"2020-08-01T02:47:16.692-04:00","content_id":572687,"subject":{"duration":"13:09","preview_image_url":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640483/7507_2Fplayer_image_2F640483_2FbOx4WNFAQd2zylUeIs3N_7_20-_20OAKLAND.jpg","versions":{"hls":""},"subtitles":[]},"position":7,"preview_image":"https://dtsvkkjw40x57.cloudfront.net/images/videos/640483/7507_2Fplayer_image_2F640483_2FbOx4WNFAQd2zylUeIs3N_7_20-_20OAKLAND.jpg","description":null,"downloadable":false,"chapter_type":"video","wait_for_drip":null,"drip_in":0,"has_access":false,"download_url":"","subject_id":640483}]
+[
+  {
+    "id": 1119397,
+    "title": "Episode 1 - Arizona",
+    "created_at": "2020-08-01T02:41:22.642-04:00",
+    "content_id": 572687,
+    "subject": {
+      "duration": "11:49",
+      "preview_image_url": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640481/7507_2Fplayer_image_2F640481_2FrGLWEiLAQ8288L28tIXj_1_20-_20ARIZONA.jpg",
+      "versions": {
+        "hls": ""
+      },
+      "subtitles": [
+        {
+          "id": 19274,
+          "language": "en",
+          "vtt_file": {
+            "url": "https://dtsvkkjw40x57.cloudfront.net/sub/19274/7507_2Fsubtitles_2F5agErxdtQWuQym8IaeIG_Episode_201_20_Final_3_.vtt"
+          },
+          "label": "English CC"
+        }
+      ]
+    },
+    "position": 1,
+    "preview_image": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640481/7507_2Fplayer_image_2F640481_2FrGLWEiLAQ8288L28tIXj_1_20-_20ARIZONA.jpg",
+    "description": null,
+    "downloadable": false,
+    "chapter_type": "video",
+    "wait_for_drip": null,
+    "drip_in": 0,
+    "has_access": true,
+    "download_url": "",
+    "subject_id": 640481
+  },
+  {
+    "id": 1119398,
+    "title": "Episode 2 -  Chicago",
+    "created_at": "2020-08-01T02:41:22.692-04:00",
+    "content_id": 572687,
+    "subject": {
+      "duration": "10:51",
+      "preview_image_url": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640480/7507_2Fplayer_image_2F640480_2FLvVqJ0leR46xl8fpMajp_2_20-_20CHICAGO.jpg",
+      "versions": {
+        "hls": ""
+      },
+      "subtitles": []
+    },
+    "position": 2,
+    "preview_image": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640480/7507_2Fplayer_image_2F640480_2FLvVqJ0leR46xl8fpMajp_2_20-_20CHICAGO.jpg",
+    "description": null,
+    "downloadable": false,
+    "chapter_type": "video",
+    "wait_for_drip": null,
+    "drip_in": 0,
+    "has_access": false,
+    "download_url": "",
+    "subject_id": 640480
+  },
+  {
+    "id": 1119399,
+    "title": "Episode 3 - Dearborn",
+    "created_at": "2020-08-01T02:41:22.767-04:00",
+    "content_id": 572687,
+    "subject": {
+      "duration": "10:46",
+      "preview_image_url": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640479/7507_2Fplayer_image_2F640479_2Ftyj7pwjDTaSZTibQBNri_3_20-_20_20DEARBORN.jpg",
+      "versions": {
+        "hls": ""
+      },
+      "subtitles": []
+    },
+    "position": 3,
+    "preview_image": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640479/7507_2Fplayer_image_2F640479_2Ftyj7pwjDTaSZTibQBNri_3_20-_20_20DEARBORN.jpg",
+    "description": null,
+    "downloadable": false,
+    "chapter_type": "video",
+    "wait_for_drip": null,
+    "drip_in": 0,
+    "has_access": false,
+    "download_url": "",
+    "subject_id": 640479
+  },
+  {
+    "id": 1119400,
+    "title": "Episode 4 - Wisconsin",
+    "created_at": "2020-08-01T02:41:22.835-04:00",
+    "content_id": 572687,
+    "subject": {
+      "duration": "10:08",
+      "preview_image_url": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640476/7507_2Fplayer_image_2F640476_2FvovGCeehTaSZPI2dysx6_WISCONSIN_20THUMB_203.jpg",
+      "versions": {
+        "hls": ""
+      },
+      "subtitles": []
+    },
+    "position": 4,
+    "preview_image": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640476/7507_2Fplayer_image_2F640476_2FvovGCeehTaSZPI2dysx6_WISCONSIN_20THUMB_203.jpg",
+    "description": null,
+    "downloadable": false,
+    "chapter_type": "video",
+    "wait_for_drip": null,
+    "drip_in": 0,
+    "has_access": false,
+    "download_url": "",
+    "subject_id": 640476
+  },
+  {
+    "id": 1119401,
+    "title": "Episode 5 - NYC & DC",
+    "created_at": "2020-08-01T02:41:22.900-04:00",
+    "content_id": 572687,
+    "subject": {
+      "duration": "12:13",
+      "preview_image_url": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640482/7507_2Fplayer_image_2F640482_2FxchqiVZoQECBMMubW0b7_5_20-_20Nyc_20DC.jpg",
+      "versions": {
+        "hls": ""
+      },
+      "subtitles": []
+    },
+    "position": 5,
+    "preview_image": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640482/7507_2Fplayer_image_2F640482_2FxchqiVZoQECBMMubW0b7_5_20-_20Nyc_20DC.jpg",
+    "description": null,
+    "downloadable": false,
+    "chapter_type": "video",
+    "wait_for_drip": null,
+    "drip_in": 0,
+    "has_access": false,
+    "download_url": "",
+    "subject_id": 640482
+  },
+  {
+    "id": 1119402,
+    "title": "Episode 6 - New Orleans",
+    "created_at": "2020-08-01T02:41:22.976-04:00",
+    "content_id": 572687,
+    "subject": {
+      "duration": "10:22",
+      "preview_image_url": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640477/7507_2Fplayer_image_2F640477_2F0vKymLVXR3yi9Uu8arb8_6_20-_20NEW_20ORLEANS.jpg",
+      "versions": {
+        "hls": ""
+      },
+      "subtitles": []
+    },
+    "position": 6,
+    "preview_image": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640477/7507_2Fplayer_image_2F640477_2F0vKymLVXR3yi9Uu8arb8_6_20-_20NEW_20ORLEANS.jpg",
+    "description": null,
+    "downloadable": false,
+    "chapter_type": "video",
+    "wait_for_drip": null,
+    "drip_in": 0,
+    "has_access": false,
+    "download_url": "",
+    "subject_id": 640477
+  },
+  {
+    "id": 1119404,
+    "title": "Episode 7 - Oakland",
+    "created_at": "2020-08-01T02:47:16.692-04:00",
+    "content_id": 572687,
+    "subject": {
+      "duration": "13:09",
+      "preview_image_url": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640483/7507_2Fplayer_image_2F640483_2FbOx4WNFAQd2zylUeIs3N_7_20-_20OAKLAND.jpg",
+      "versions": {
+        "hls": ""
+      },
+      "subtitles": []
+    },
+    "position": 7,
+    "preview_image": "https://dtsvkkjw40x57.cloudfront.net/images/videos/640483/7507_2Fplayer_image_2F640483_2FbOx4WNFAQd2zylUeIs3N_7_20-_20OAKLAND.jpg",
+    "description": null,
+    "downloadable": false,
+    "chapter_type": "video",
+    "wait_for_drip": null,
+    "drip_in": 0,
+    "has_access": false,
+    "download_url": "",
+    "subject_id": 640483
+  },
+  {
+    "id": 1711409,
+    "title": "Bonus Expeditions",
+    "created_at": 1612885254,
+    "content_id": 907877,
+    "subject": null,
+    "position": 8,
+    "preview_image": "",
+    "description": null,
+    "downloadable": null,
+    "chapter_type": "divider",
+    "wait_for_drip": null,
+    "drip_in": 0,
+    "has_access": false,
+    "download_url": "",
+    "subject_id": null,
+    "short_description": false
+  }
+]

--- a/tests/resources/lib/test_api.py
+++ b/tests/resources/lib/test_api.py
@@ -39,9 +39,9 @@ class LoadChapterDetailsTestCase(TestCase):
         # https://means.tv/programs/latm?categoryId=20473
         with open(_LATM_CHAPTERS_JSON, "r") as response_file:
             response_json = json.load(response_file)
-            m.get('https://means.tv/api/chapters/?ids%5B%5D=1119397&ids%5B%5D=1119398&ids%5B%5D=1119399&ids%5B%5D=1119400&ids%5B%5D=1119401&ids%5B%5D=1119402&ids%5B%5D=1119404',
+            m.get('https://means.tv/api/chapters/?ids%5B%5D=1119397&ids%5B%5D=1119398&ids%5B%5D=1119399&ids%5B%5D=1119400&ids%5B%5D=1119401&ids%5B%5D=1119402&ids%5B%5D=1119404&ids%5B%5D=1711409',
                   json=response_json)
-        chapters = load_chapters([1119397, 1119398, 1119399, 1119400, 1119401, 1119402, 1119404])
+        chapters = load_chapters([1119397, 1119398, 1119399, 1119400, 1119401, 1119402, 1119404, 1711409])
         self.assertEquals(len(chapters), 7)
         self.assertTrue(all([isinstance(c, ChapterVideo) for c in chapters]))
         self.assertEquals(chapters[0].title, 'Episode 1 - Arizona')


### PR DESCRIPTION
Fixing two current issues with the API:
* new chapter item type `divider` is filtered (only `video` is shown)
* categories list now needs a header for fastly cdn (someone this applies only to this endpoint :see_no_evil: )

Notes: I added a new IT for the categories page as this is the main entrypoint for the addon